### PR TITLE
Add LinkedIn URLs to sample user data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,13 +118,13 @@ app.get('/proxy/image', proxyLimiter, async (req, res) => {
 });
 
 let users = [
-    {id: 1, firstName: 'Alice', lastName: 'Smith', role: 'admin', email: 'alice@example.com', gender: 'female', phoneNumber: '+1234567890'},
-    {id: 2, firstName: 'Bob', lastName: 'Johnson', role: 'user', email: 'bob@example.com', gender: 'male', phoneNumber: '+1987654321'},
+    {id: 1, firstName: 'Alice', lastName: 'Smith', role: 'admin', email: 'alice@example.com', gender: 'female', phoneNumber: '+1234567890', linkedinUrl: 'https://www.linkedin.com/in/alice-smith'},
+    {id: 2, firstName: 'Bob', lastName: 'Johnson', role: 'user', email: 'bob@example.com', gender: 'male', phoneNumber: '+1987654321', linkedinUrl: 'https://www.linkedin.com/in/bob-johnson'},
     {id: 3, firstName: 'Charlie', lastName: 'Brown', role: 'user', email: 'charlie@example.com', gender: 'male'},
-    {id: 4, firstName: 'David', lastName: 'Williams', role: 'admin', email: 'david@example.com', gender: 'male', phoneNumber: '+1555123456'},
+    {id: 4, firstName: 'David', lastName: 'Williams', role: 'admin', email: 'david@example.com', gender: 'male', phoneNumber: '+1555123456', linkedinUrl: 'https://www.linkedin.com/in/david-williams'},
     {id: 5, firstName: 'Eve', lastName: 'Davis', role: 'user', email: 'eve@example.com', gender: 'female'},
     {id: 6, firstName: 'Frank', lastName: 'Miller', role: 'moderator', email: 'frank@example.com', gender: 'male', phoneNumber: '+1444987654'},
-    {id: 7, firstName: 'Grace', lastName: 'Garcia', role: 'user', email: 'grace@example.com', gender: 'female', phoneNumber: '+1777888999'},
+    {id: 7, firstName: 'Grace', lastName: 'Garcia', role: 'user', email: 'grace@example.com', gender: 'female', phoneNumber: '+1777888999', linkedinUrl: 'https://www.linkedin.com/in/grace-garcia'},
     {id: 8, firstName: 'Hank', lastName: 'Martinez', role: 'admin', email: 'hank@example.com', gender: 'male'},
     {id: 9, firstName: 'Ivy', lastName: 'Lopez', role: 'user', email: 'ivy@example.com', gender: 'female', phoneNumber: '+1888123456'},
     {id: 10, firstName: 'Jack', lastName: 'Gonzalez', role: 'user', email: 'jack@example.com', gender: 'male', phoneNumber: '+1999765432'},


### PR DESCRIPTION
## Summary
This PR adds LinkedIn profile URLs to several sample users in the backend data to support the new LinkedIn button feature in the frontend.

## Changes
- Added `linkedinUrl` field to 4 out of 10 sample users:
  - Alice Smith (id: 1)
  - Bob Johnson (id: 2)
  - David Williams (id: 4)
  - Grace Garcia (id: 7)
- Other users remain without LinkedIn URLs to demonstrate conditional rendering

## Technical Details
- **Language**: Node.js/Express
- **Files Modified**: `src/index.js`
- Sample LinkedIn URLs follow the pattern: `https://www.linkedin.com/in/[firstname-lastname]`

## Testing Notes
- Users with `linkedinUrl` will display the LinkedIn button in the frontend
- Users without `linkedinUrl` will not show the button (conditional rendering)
- No breaking changes to existing API endpoints
- Field is optional and backward compatible

## Related
This backend change supports the frontend PR that adds LinkedIn button functionality to user profile cards.