### PR TITLE
Add LinkedIn URL support to user profiles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,21 @@ function isValidEmail(email) {
   return emailRegex.test(email);
 }
 
+// Function to validate LinkedIn URL
+function isValidLinkedInUrl(url) {
+  if (!url) return true; // optional field
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== 'https:') return false;
+    if (!parsedUrl.hostname.includes('linkedin.com')) return false;
+    // Max length 512 chars
+    if (url.length > 512) return false;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 // Proxy endpoint for images
 app.get('/proxy/image', proxyLimiter, async (req, res) => {
   const { url } = req.query;
@@ -118,8 +133,8 @@ app.get('/proxy/image', proxyLimiter, async (req, res) => {
 });
 
 let users = [
-    {id: 1, firstName: 'Alice', lastName: 'Smith', role: 'admin', email: 'alice@example.com', gender: 'female', phoneNumber: '+1234567890'},
-    {id: 2, firstName: 'Bob', lastName: 'Johnson', role: 'user', email: 'bob@example.com', gender: 'male', phoneNumber: '+1987654321'},
+    {id: 1, firstName: 'Alice', lastName: 'Smith', role: 'admin', email: 'alice@example.com', gender: 'female', phoneNumber: '+1234567890', linkedinUrl: 'https://www.linkedin.com/in/alice-smith-example'},
+    {id: 2, firstName: 'Bob', lastName: 'Johnson', role: 'user', email: 'bob@example.com', gender: 'male', phoneNumber: '+1987654321', linkedinUrl: 'https://www.linkedin.com/in/bob-johnson-example'},
     {id: 3, firstName: 'Charlie', lastName: 'Brown', role: 'user', email: 'charlie@example.com', gender: 'male'},
     {id: 4, firstName: 'David', lastName: 'Williams', role: 'admin', email: 'david@example.com', gender: 'male', phoneNumber: '+1555123456'},
     {id: 5, firstName: 'Eve', lastName: 'Davis', role: 'user', email: 'eve@example.com', gender: 'female'},
@@ -184,7 +199,7 @@ app.get('/api/users', (req, res) => {
 
 // POST /api/users
 app.post('/api/users', (req, res) => {
-    const {firstName, lastName, role, email, gender, phoneNumber} = req.body;
+    const {firstName, lastName, role, email, gender, phoneNumber, linkedinUrl} = req.body;
     if (!isValidName(firstName) || !isValidName(lastName)) {
         return res.status(400).json({error: 'Invalid first or last name'});
     }
@@ -197,6 +212,9 @@ app.post('/api/users', (req, res) => {
     if (phoneNumber && !isValidPhoneNumber(phoneNumber)) {
         return res.status(400).json({error: 'Invalid phone number format (E.164)'});
     }
+    if (!isValidLinkedInUrl(linkedinUrl)) {
+        return res.status(400).json({error: 'Invalid LinkedIn URL'});
+    }
     const newUser = {
         id: Math.floor(Math.random() * 1000),
         firstName: firstName.trim(),
@@ -205,6 +223,7 @@ app.post('/api/users', (req, res) => {
         email,
         gender,
         phoneNumber: phoneNumber || null,
+        linkedinUrl: linkedinUrl || null,
     };
     users.push(newUser);
     res.status(201).json({
@@ -220,7 +239,7 @@ app.put('/api/users/:id', (req, res) => {
     if (index === -1) {
         return res.status(404).json({error: 'User not found'});
     }
-    const {firstName, lastName, role, email, gender, phoneNumber} = req.body;
+    const {firstName, lastName, role, email, gender, phoneNumber, linkedinUrl} = req.body;
     if (firstName !== undefined && !isValidName(firstName)) {
         return res.status(400).json({error: 'Invalid first name'});
     }
@@ -236,12 +255,16 @@ app.put('/api/users/:id', (req, res) => {
     if (phoneNumber && !isValidPhoneNumber(phoneNumber)) {
         return res.status(400).json({error: 'Invalid phone number format (E.164)'});
     }
+    if (linkedinUrl !== undefined && !isValidLinkedInUrl(linkedinUrl)) {
+        return res.status(400).json({error: 'Invalid LinkedIn URL'});
+    }
     if (firstName !== undefined) users[index].firstName = firstName.trim();
     if (lastName !== undefined) users[index].lastName = lastName.trim();
     if (role !== undefined) users[index].role = role;
     if (email !== undefined) users[index].email = email;
     if (gender !== undefined) users[index].gender = gender;
     if (phoneNumber !== undefined) users[index].phoneNumber = phoneNumber;
+    if (linkedinUrl !== undefined) users[index].linkedinUrl = linkedinUrl;
     res.json({
         message: 'User updated successfully',
         user: users[index],


### PR DESCRIPTION
This PR adds support for LinkedIn URLs in user data structures and API endpoints.

Changes:
- Added linkedinUrl field to user objects
- Implemented validation for LinkedIn URLs
- Updated POST /api/users to accept and store linkedinUrl
- Updated PUT /api/users/:id to handle linkedinUrl updates
- Added sample LinkedIn URLs to Alice and Bob's profiles

This enables the frontend to display LinkedIn buttons on user profile cards where available.